### PR TITLE
Add property for column count

### DIFF
--- a/src/CsvSwan.Tests/FromStringTests.cs
+++ b/src/CsvSwan.Tests/FromStringTests.cs
@@ -413,5 +413,16 @@ one, two, 3";
                 TestHelpers.RowMatch(rows[2], string.Empty, string.Empty, "mushroom");
             }
         }
+
+        [Fact]
+        public void HasRightColumnCount()
+        {
+            const string input = "one,two,three,four,\r\none,two,three,four,five";
+
+            using (var csv = Csv.FromString(input))
+            {
+                Assert.Equal(5, csv.ColumnCount);
+            }
+        }
     }
 }

--- a/src/CsvSwan/Csv.cs
+++ b/src/CsvSwan/Csv.cs
@@ -84,6 +84,11 @@ namespace CsvSwan
         public IReadOnlyList<string> HeaderRow { get; }
 
         /// <summary>
+        /// Get the number of columns in this CSV.
+        /// </summary>
+        public int ColumnCount { get; }
+
+        /// <summary>
         /// Step through the rows in this CSV. <see cref="RowAccessor"/> should not be stored.
         /// </summary>
         public IEnumerable<RowAccessor> Rows
@@ -133,6 +138,8 @@ namespace CsvSwan
             {
                 HeaderRow = new string[0];
             }
+
+            ColumnCount = reader.GetColumnCount();
         }
 
         /// <summary>

--- a/src/CsvSwan/CsvReader.cs
+++ b/src/CsvSwan/CsvReader.cs
@@ -321,6 +321,25 @@
             }
         }
 
+        /// <summary>
+        /// Get the number of columns by measuring the first row, header or not.
+        /// </summary>
+        /// <returns>The number of columns</returns>
+        public int GetColumnCount()
+        {
+            lock (mutex)
+            {
+                SeekStart(false);
+
+                if (ReadRow(out var row))
+                {
+                    return row.Count;
+                }
+
+                return 0;
+            }
+        }
+
         /// <inheritdoc />
         public void Dispose()
         {


### PR DESCRIPTION
As requested in #1 adds a property to get the column count by using:

```cs
using var csv = Csv.FromString(input);

Console.WriteLine(csv.ColumnCount);
```

Column count is measured from the first row, which should with all common exporters such as Excel always be the same as the entire document.
